### PR TITLE
Adding Introductory Quickstarts

### DIFF
--- a/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
+++ b/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   conclusion: "Congratulations! **Red Hat Coolstore** app is ready to use in the Dev environment."
   description: Onboarding developers to the Coolstore app project
-  displayName: Coolstore app developers quickstart
+  displayName: Red Hat Coolstore App Developers
   durationMinutes: 5
   icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
   introduction: "**Red Hat Coolstore** is GitOps-driven microservices-based application running on Red Hat OpenShift Container Platform."
@@ -22,4 +22,4 @@ spec:
     summary:
       failed: Try the steps again.
       success: Great work! You join the Dev environment for the Coolstore app and started OpenShift DevSpaces
-    title: Red Hat Coolstore app development
+    title: Coolstore Introduction + Dev Spaces

--- a/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
+++ b/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
@@ -1,0 +1,25 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  annotations:
+    capability.openshift.io/name: Console
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: coolstore-app
+spec:
+  conclusion: "Congratulations! **Red Hat Coolstore** app is ready to use in the Dev environment."
+  description: Onboarding developers to the Coolstore app project
+  displayName: Coolstore app developers quickstart
+  durationMinutes: 5
+  icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
+  introduction: "**Red Hat Coolstore** is GitOps-driven microservices-based application running on Red Hat OpenShift Container Platform."
+  tasks:
+  - description: "This cluster (ROSA) is the Dev/CI cluster.\n\nTo access the app, follow these steps:\n\n1. Enter the developer perspective: In the main navigation, select the dropdown menu and select **Developer**.\n\n1. In the projects list, select **coolstore-dev**\n\n2. From the **Topology** view, click on the OpenShift DevSpaces icon showing **Edit source code** next to microservice you want to start coding."
+    review:
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+      instructions: "####  Verify that the Coolstore app is installed in the Dev project:\n\nDoes the **Topology** view show four applications?"
+    summary:
+      failed: Try the steps again.
+      success: Great work! You join the Dev environment for the Coolstore app and started OpenShift DevSpaces
+    title: Red Hat Coolstore app development

--- a/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
+++ b/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-  name: coolstore-app
+  name: Red-Hat-Coolstore 
 spec:
   conclusion: "Congratulations! **Red Hat Coolstore** app is ready to use in the Dev environment."
   description: Onboarding developers to the Coolstore app project

--- a/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
+++ b/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-  name: Red-Hat-Coolstore 
+  name: red-hat-coolstore 
 spec:
   conclusion: "Congratulations! **Red Hat Coolstore** app is ready to use in the Dev environment."
   description: Onboarding developers to the Coolstore app project

--- a/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
+++ b/infra/components/quickstarts/overlays/default/coolstore-quickstart.yaml
@@ -23,3 +23,5 @@ spec:
       failed: Try the steps again.
       success: Great work! You join the Dev environment for the Coolstore app and started OpenShift DevSpaces
     title: Coolstore Introduction + Dev Spaces
+  - description: "The Coolstore App relies on **CI/CD pipelines**. \n\n Click **Pipelines**, on the left hand side. Take a minute to look through each pipeline. \n\n When a specific pipeline is selected, details such the **tasks, steps, and logs** will be available. \n\n"
+    title: Pipelines Introduction


### PR DESCRIPTION
Intro quickstart for Coolstore Demo

Features Red Hat Logo, called Red-Hat-Coolstore

Asks users to head to developer view, check there are 4 services, and confirm.

After they launch dev spaces